### PR TITLE
chore: use dprint to format the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-* **`0.1.0`**
-    * Initial implementation 
-* **`0.2.0`**
-    * Fix bugs
-    * Change contract for the context* 
-**`0.3.0`**
-    * Fix bugs with html tags in labels
-**`0.4.0`**
-    * Add method exec_dot
-
+- **`0.1.0`**
+  - Initial implementation
+- **`0.2.0`**
+  - Fix bugs
+  - Change contract for the context*
+    **`0.3.0`**
+  - Fix bugs with html tags in labels
+    **`0.4.0`**
+  - Add method exec_dot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - **`0.2.0`**
   - Fix bugs
   - Change contract for the context*
-    **`0.3.0`**
+- **`0.3.0`**
   - Fix bugs with html tags in labels
-    **`0.4.0`**
+- **`0.4.0`**
   - Add method exec_dot

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,24 +1,23 @@
 [package]
 name = "graphviz-rust"
-description = "The library provides the basic access to the graphs in graphviz format with ability to import into or export from it."
 version = "0.4.0"
-edition = "2021"
 authors = ["BorisZhguchev <zhguchev@gmail.com>"]
-license-file = "LICENSE"
+categories = ["parsing", "visualization", "api-bindings"]
+edition = "2021"
 homepage = "https://github.com/besok/graphviz-rust"
-repository = "https://github.com/besok/graphviz-rust"
-readme = "README.md"
 keywords = ["graph", "graphviz", "dotfile", "dot", "visualize"]
-categories = ["parsing","visualization","api-bindings"]
-
+license-file = "LICENSE"
+readme = "README.md"
+repository = "https://github.com/besok/graphviz-rust"
+description = "The library provides the basic access to the graphs in graphviz format with ability to import into or export from it."
 
 [dependencies]
+dot-generator = { path = "dot-generator", version = "0.2.0" }
+dot-structures = { path = "dot-structures", version = "0.1.0" }
+into-attr = { path = "into-attr", version = "0.1.0" }
+into-attr-derive = { path = "into-attr-derive", version = "0.1.0" }
 pest = "2.0"
 pest_derive = "2.0"
 rand = "0.8.4"
-into-attr = { path = "into-attr", version="0.1.0" }
-into-attr-derive = {path = "into-attr-derive", version="0.1.0"}
-dot-structures = { path = "dot-structures", version="0.1.0" }
-dot-generator = { path = "dot-generator", version="0.2.0" }
 tempfile = "3.2.0"
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ into or export from it.
 #### Parse dot source
 
 ```rust
-use dot_structures::*;
 use dot_generator::*;
+use dot_structures::*;
 
 fn parse_test() {
-    let g: Graph = parse(r#"
+    let g: Graph = parse(
+        r#"
         strict digraph t {
             aa[color=green]
             subgraph v {
@@ -24,21 +25,23 @@ fn parse_test() {
             aa -> be -> subgraph v { d -> aaa}
             aa -> aaa -> v
         }
-        "#).unwrap();
+        "#,
+    )
+    .unwrap();
 
     assert_eq!(
         g,
         graph!(strict di id!("t");
-              node!("aa";attr!("color","green")),
-              subgraph!("v";
-                node!("aa"; attr!("shape","square")),
-                subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
-                node!("aaa";attr!("color","red")),
-                edge!(node_id!("aaa") => node_id!("bbb"))
-                ),
-              edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
-              edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
-            )
+          node!("aa";attr!("color","green")),
+          subgraph!("v";
+            node!("aa"; attr!("shape","square")),
+            subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
+            node!("aaa";attr!("color","red")),
+            edge!(node_id!("aaa") => node_id!("bbb"))
+            ),
+          edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
+          edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+        )
     )
 }
 ```
@@ -46,42 +49,50 @@ fn parse_test() {
 #### Print graph into dot source
 
 ```rust
- use dot_structures::*;
 use dot_generator::*;
-use graphviz_rust::printer::{PrinterContext, DotPrinter};
+use dot_structures::*;
+use graphviz_rust::printer::{DotPrinter, PrinterContext};
 
 fn print_test() {
     let mut g = graph!(strict di id!("id"));
-    assert_eq!("strict digraph id {}".to_string(), g.print(&mut PrinterContext::default()));
+    assert_eq!(
+        "strict digraph id {}".to_string(),
+        g.print(&mut PrinterContext::default())
+    );
 }
- ```
+```
 
 #### Transform graph into external formats with cmd engine
 
 ```rust
- use dot_structures::*;
 use dot_generator::*;
-use graphviz_rust::{exec, parse};
-use graphviz_rust::cmd::{CommandArg, Format};
-use graphviz_rust::printer::{PrinterContext, DotPrinter};
-use graphviz_rust::attributes::*;
+use dot_structures::*;
+use graphviz_rust::{
+    attributes::*,
+    cmd::{CommandArg, Format},
+    exec, parse,
+    printer::{DotPrinter, PrinterContext},
+};
 
 fn output_test() {
     let mut g = graph!(id!("id");
-             node!("nod"),
-             subgraph!("sb";
-                 edge!(node_id!("a") => subgraph!(;
-                    node!("n";
-                    NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
-                ))
-            ),
-            edge!(node_id!("a1") => node_id!(esc "a2"))
-        );
-    let graph_svg = exec(g, &mut PrinterContext::default(), vec![
-        CommandArg::Format(Format::Svg),
-    ]).unwrap();
+         node!("nod"),
+         subgraph!("sb";
+             edge!(node_id!("a") => subgraph!(;
+                node!("n";
+                NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
+            ))
+        ),
+        edge!(node_id!("a1") => node_id!(esc "a2"))
+    );
+    let graph_svg = exec(
+        g,
+        &mut PrinterContext::default(),
+        vec![CommandArg::Format(Format::Svg)],
+    )
+    .unwrap();
 }
- ```
+```
 
 ### Structure:
 
@@ -89,16 +100,16 @@ The structure pursues to follow the dot [notation](https://graphviz.org/doc/info
 straight accordance. The structures can be found in `dot_structures::*` and has the following denotion:
 
 ```text
- strict digraph t {                     : graph with t as id
-         aa[color=green]                : node aa and attributes in []
-         subgraph v {                   : subgraph v
- 	        aa[shape=square]            : node aa in subgraph 
- 	        subgraph vv{a2 -> b2}       : another subgraph carrying edge inside( a type of the edge is Pair)
- 	        aaa[color=red]
- 	        aaa -> subgraph { d -> aaa} : subgraph id is anonymous id
-         }
-        aa -> be -> d -> aaa            : other edge with a type Chain
-    }
+strict digraph t {                     : graph with t as id
+        aa[color=green]                : node aa and attributes in []
+        subgraph v {                   : subgraph v
+	        aa[shape=square]            : node aa in subgraph 
+	        subgraph vv{a2 -> b2}       : another subgraph carrying edge inside( a type of the edge is Pair)
+	        aaa[color=red]
+	        aaa -> subgraph { d -> aaa} : subgraph id is anonymous id
+        }
+       aa -> be -> d -> aaa            : other edge with a type Chain
+   }
 ```
 
 ### Generate a dot structure:
@@ -114,15 +125,17 @@ have the following syntax:
 ```rust
 assert_eq!(
     node!("node_id"; attr!("atr1","val1"),attr!("atr2","val2")),
-    node!("node_id", vec![attr!("atr1","val1"),attr!("atr2","val2")])
+    node!(
+        "node_id",
+        vec![attr!("atr1", "val1"), attr!("atr2", "val2")]
+    )
 );
-
 ```
 
 The macros can be found in `dot_generator::*` and has the following denotion:
 
 ```rust
-       fn graph_test() {
+fn graph_test() {
     use dot_generator::*;
     use dot_structures::*;
 
@@ -141,16 +154,16 @@ The macros can be found in `dot_generator::*` and has the following denotion:
             "#;
 
     graph!(strict di id!("t");
-                  node!("aa";attr!("color","green")),
-                  subgraph!("v";
-                    node!("aa"; attr!("shape","square")),
-                    subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
-                    node!("aaa";attr!("color","red")),
-                    edge!(node_id!("aaa") => node_id!("bbb"))
-                    ),
-                  edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
-                  edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
-                );
+      node!("aa";attr!("color","green")),
+      subgraph!("v";
+        node!("aa"; attr!("shape","square")),
+        subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
+        node!("aaa";attr!("color","red")),
+        edge!(node_id!("aaa") => node_id!("bbb"))
+        ),
+      edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
+      edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+    );
 }
 ```
 
@@ -165,18 +178,21 @@ support it, the library provides a set of structures alleviating the navigation 
   structures `graphviz_rust::attributes::{EdgeAttributes,SubgraphAttributes GraphAttributes, NodeAttributes}`
   grouping and displaying which attribute belongs to the struct.
 
- ```rust
-    use graphviz_rust::attributes::{color, color_name, GraphAttributes, NodeAttributes};
-use into_attr::IntoAttribute;
-use dot_structures::*;
+```rust
 use dot_generator::*;
+use dot_structures::*;
+use graphviz_rust::attributes::{
+    color, color_name, GraphAttributes, NodeAttributes,
+};
+use into_attr::IntoAttribute;
 
 fn test() {
-    assert_eq!(GraphAttributes::center(true), attr!("center",true));
+    assert_eq!(GraphAttributes::center(true), attr!("center", true));
     assert_eq!(
         NodeAttributes::color(color_name::antiquewhite1),
-        attr!("color","antiquewhite1"));
-    assert_eq!(color::default().into_attr(), attr!("color","black"));
+        attr!("color", "antiquewhite1")
+    );
+    assert_eq!(color::default().into_attr(), attr!("color", "black"));
 }
 ```
 
@@ -185,22 +201,26 @@ fn test() {
 The trait `DotPrinter` is summoned to transform a graph structure into string.
 
 ```rust
-     use dot_generator::*;
+use dot_generator::*;
 use dot_structures::*;
-use graphviz_rust::printer::{PrinterContext, DotPrinter};
+use graphviz_rust::printer::{DotPrinter, PrinterContext};
 
 fn subgraph_test() {
     let mut ctx = PrinterContext::default();
-    let s = subgraph!("id"; node!("abc"), edge!(node_id!("a") => node_id!("b")));
+    let s =
+        subgraph!("id"; node!("abc"), edge!(node_id!("a") => node_id!("b")));
 
-    assert_eq!(s.print(&mut ctx), "subgraph id {\n    abc\n    a -- b \n}".to_string());
+    assert_eq!(
+        s.print(&mut ctx),
+        "subgraph id {\n    abc\n    a -- b \n}".to_string()
+    );
 }
 ```
 
 The module allows adjusting some parameters such as indent step or line separator using `PrinterContext`:
 
 ```rust
-     fn ctx() {
+fn ctx() {
     use self::graphviz_rust::printer::PrinterContext;
     let mut ctx = PrinterContext::default();
 
@@ -214,24 +234,27 @@ The module allows adjusting some parameters such as indent step or line separato
 ### External formats and others using cmd engine
 
 The library provides an ability to use [command commands](https://graphviz.org/doc/info/command.html) from the rust
-code. 
+code.
 The details are denoted in `graphviz_rust::{exec}` and `graphviz_rust::{exec_dot}` methods
 
 ```rust
-  fn output_test() {
+fn output_test() {
     let mut g = graph!(id!("id"));
-    exec(g, PrinterContext::default(), vec![
-        CommandArg::Format(Format::Svg),
-        CommandArg::Output("path_to_file".to_string())
-    ]);
+    exec(
+        g,
+        PrinterContext::default(),
+        vec![
+            CommandArg::Format(Format::Svg),
+            CommandArg::Output("path_to_file".to_string()),
+        ],
+    );
 }
 ```
-
 
 ### Caveats
 
 #### The [command client](https://graphviz.org/download/) should be installed
-Since, the library operates with a cmd client to execute the commands, the client should be installed beforehand,
-otherwise, the errors like: `No file or directory found` or `program not found` (depending on the OS) 
-will be popped up.
 
+Since, the library operates with a cmd client to execute the commands, the client should be installed beforehand,
+otherwise, the errors like: `No file or directory found` or `program not found` (depending on the OS)
+will be popped up.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ straight accordance. The structures can be found in `dot_structures::*` and has 
 strict digraph t {                     : graph with t as id
         aa[color=green]                : node aa and attributes in []
         subgraph v {                   : subgraph v
-	        aa[shape=square]            : node aa in subgraph 
+	        aa[shape=square]            : node aa in subgraph
 	        subgraph vv{a2 -> b2}       : another subgraph carrying edge inside( a type of the edge is Pair)
 	        aaa[color=red]
 	        aaa -> subgraph { d -> aaa} : subgraph id is anonymous id
@@ -255,6 +255,4 @@ fn output_test() {
 
 #### The [command client](https://graphviz.org/download/) should be installed
 
-Since, the library operates with a cmd client to execute the commands, the client should be installed beforehand,
-otherwise, the errors like: `No file or directory found` or `program not found` (depending on the OS)
-will be popped up.
+Since, the library operates with a cmd client to execute the commands, the client should be installed beforehand, otherwise, the errors like: `No file or directory found` or `program not found` (depending on the OS) will be popped up.

--- a/dot-generator/Cargo.toml
+++ b/dot-generator/Cargo.toml
@@ -6,4 +6,4 @@ license-file = "../LICENSE"
 description = "the set of macros to generate dot files"
 
 [dependencies]
-dot-structures={path = "../dot-structures", version = "0.1.0"}
+dot-structures = { path = "../dot-structures", version = "0.1.0" }

--- a/dot-generator/src/lib.rs
+++ b/dot-generator/src/lib.rs
@@ -1,6 +1,6 @@
 //! # The set of macroses helping to generate the elements of graphviz
 //! The set helps to generate the major components of the graphviz dot notation
-//! endevouring to follow comparatively close to the language [`notation`]
+//! endeavouring to follow comparatively close to the language [`notation`]
 //!
 //! [`notation`]: https://graphviz.org/doc/info/lang.html
 //! # Description:
@@ -14,36 +14,36 @@
 //!
 //! # Examples:
 //! ```rust
-//!        fn graph_test() {
-//!        use dot_generator::*;
-//!        use dot_structures::*;
+//! fn graph_test() {
+//!     use dot_generator::*;
+//!     use dot_structures::*;
 //!
-//!        let g = r#"
-//!        strict digraph t {
-//!            aa[color=green]
-//!            subgraph v {
-//!                aa[shape=square]
-//!                subgraph vv{a2 -> b2}
-//!                aaa[color=red]
-//!                aaa -> bbb
-//!            }
-//!            aa -> be -> subgraph v { d -> aaa}
-//!            aa -> aaa -> v
-//!        }
-//!        "#;
+//!     let g = r#"
+//!         strict digraph t {
+//!             aa[color=green]
+//!             subgraph v {
+//!                 aa[shape=square]
+//!                 subgraph vv{a2 -> b2}
+//!                 aaa[color=red]
+//!                 aaa -> bbb
+//!             }
+//!             aa -> be -> subgraph v { d -> aaa}
+//!             aa -> aaa -> v
+//!         }
+//!         "#;
 //!
-//!            graph!(strict di id!("t");
-//!              node!("aa";attr!("color","green")),
-//!              subgraph!("v";
-//!                node!("aa"; attr!("shape","square")),
-//!                subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
-//!                node!("aaa";attr!("color","red")),
-//!                edge!(node_id!("aaa") => node_id!("bbb"))
-//!                ),
-//!              edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
-//!              edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
-//!            );
-//!    }
+//!     graph!(strict di id!("t");
+//!       node!("aa";attr!("color","green")),
+//!       subgraph!("v";
+//!         node!("aa"; attr!("shape","square")),
+//!         subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
+//!         node!("aaa";attr!("color","red")),
+//!         edge!(node_id!("aaa") => node_id!("bbb"))
+//!         ),
+//!       edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
+//!       edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+//!     );
+//! }
 //! ```
 use dot_structures::*;
 

--- a/dot-generator/src/lib.rs
+++ b/dot-generator/src/lib.rs
@@ -50,10 +50,18 @@ use dot_structures::*;
 /// represents a port in dot lang
 #[macro_export]
 macro_rules! port {
-    () => {Port(None,None)};
-    ( , $str:expr) => { Port(None,Some($str.to_string()))};
-    ( $id:expr , $str:expr) => {Port(Some($id),Some($str.to_string()))};
-    ( $id:expr) => {Port(Some($id),None)};
+    () => {
+        Port(None, None)
+    };
+    (, $str:expr) => {
+        Port(None, Some($str.to_string()))
+    };
+    ($id:expr, $str:expr) => {
+        Port(Some($id), Some($str.to_string()))
+    };
+    ($id:expr) => {
+        Port(Some($id), None)
+    };
 }
 /// represents a node id in dot lang
 /// Essentially it is a combination of id and port
@@ -84,10 +92,18 @@ macro_rules! node_id {
 /// ```
 #[macro_export]
 macro_rules! id {
-    () => { Id::Anonymous("".to_string()) };
-    (html$e:expr) => { Id::Html(format!("{}",$e))};
-    (esc$e:expr) => { Id::Escaped(format!("\"{}\"",$e))};
-    ($e:expr) => { Id::Plain(format!("{}",$e))};
+    () => {
+        Id::Anonymous("".to_string())
+    };
+    (html $e:expr) => {
+        Id::Html(format!("{}", $e))
+    };
+    (esc $e:expr) => {
+        Id::Escaped(format!("\"{}\"", $e))
+    };
+    ($e:expr) => {
+        Id::Plain(format!("{}", $e))
+    };
 }
 
 /// represents an attribute in dot lang.
@@ -113,16 +129,21 @@ macro_rules! attr {
 /// for the underlying structure as node,edge, subgraph etc.
 /// #Example:
 /// ```rust
-///     fn stmt_test() {
-///         use dot_generator::*;
-///         use dot_structures::*;
+/// fn stmt_test() {
+///     use dot_generator::*;
+///     use dot_structures::*;
 ///
-///         assert_eq!(stmt!(node!()), Stmt::Node(Node::new(NodeId(id!(), None), vec![])));
-///     }
+///     assert_eq!(
+///         stmt!(node!()),
+///         Stmt::Node(Node::new(NodeId(id!(), None), vec![]))
+///     );
+/// }
 /// ```
 #[macro_export]
 macro_rules! stmt {
-    ($k:expr) => {Stmt::from($k)};
+    ($k:expr) => {
+        Stmt::from($k)
+    };
 }
 
 /// represents a subgraph in dot lang.
@@ -363,11 +384,19 @@ mod tests {
     fn graph_test() {
         assert_eq!(
             graph!(strict di id!("abc")),
-            Graph::DiGraph { id: id!("abc"), strict: true, stmts: vec![] }
+            Graph::DiGraph {
+                id: id!("abc"),
+                strict: true,
+                stmts: vec![]
+            }
         );
         assert_eq!(
             graph!(strict di id!("abc");stmt!(node!("abc"))),
-            Graph::DiGraph { id: id!("abc"), strict: true, stmts: vec![stmt!(node!("abc"))] }
+            Graph::DiGraph {
+                id: id!("abc"),
+                strict: true,
+                stmts: vec![stmt!(node!("abc"))]
+            }
         );
     }
 
@@ -375,54 +404,87 @@ mod tests {
     fn edge_test() {
         assert_eq!(
             edge!(node_id!("1") => node_id!("2")),
-            Edge { ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))), attributes: vec![] }
+            Edge {
+                ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))),
+                attributes: vec![]
+            }
         );
         assert_eq!(
             edge!(node_id!("1") => node_id!("2") => subgraph!("a")),
-            Edge { ty: EdgeTy::Chain(vec![Vertex::N(node_id!("1")), Vertex::N(node_id!("2")), Vertex::S(subgraph!("a"))]), attributes: vec![] }
+            Edge {
+                ty: EdgeTy::Chain(vec![
+                    Vertex::N(node_id!("1")),
+                    Vertex::N(node_id!("2")),
+                    Vertex::S(subgraph!("a"))
+                ]),
+                attributes: vec![]
+            }
         );
         assert_eq!(
             edge!(node_id!("1") => node_id!("2"), vec![attr!("a","b")]),
-            Edge { ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))), attributes: vec![attr!("a","b")] }
+            Edge {
+                ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))),
+                attributes: vec![attr!("a", "b")]
+            }
         );
         assert_eq!(
             edge!(node_id!("1") => node_id!("2"); attr!("a","b")),
-            Edge { ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))), attributes: vec![attr!("a","b")] }
+            Edge {
+                ty: EdgeTy::Pair(Vertex::N(node_id!("1")), Vertex::N(node_id!("2"))),
+                attributes: vec![attr!("a", "b")]
+            }
         );
     }
 
     #[test]
     fn stmt_test() {
-        assert_eq!(stmt!(node!()), Stmt::Node(Node::new(NodeId(id!(), None), vec![])));
+        assert_eq!(
+            stmt!(node!()),
+            Stmt::Node(Node::new(NodeId(id!(), None), vec![]))
+        );
     }
 
     #[test]
     fn subgraph_test() {
-        assert_eq!(subgraph!(), Subgraph { id: Id::Anonymous("".to_string()), stmts: vec![] });
-        assert_eq!(subgraph!("abc";node!()),
-                   Subgraph {
-                       id: Id::Plain("abc".to_string()),
-                       stmts: vec![stmt!(node!())],
-                   });
+        assert_eq!(
+            subgraph!(),
+            Subgraph {
+                id: Id::Anonymous("".to_string()),
+                stmts: vec![]
+            }
+        );
+        assert_eq!(
+            subgraph!("abc";node!()),
+            Subgraph {
+                id: Id::Plain("abc".to_string()),
+                stmts: vec![stmt!(node!())],
+            }
+        );
     }
 
     #[test]
     fn node_test() {
         assert_eq!(node!(), Node::new(NodeId(id!(), None), vec![]));
-        assert_eq!(node!(html "abc"; attr!("a","a")),
-                   Node::new(NodeId(id!(html "abc"), None),
-                             vec![attr!("a","a")]));
-        assert_eq!(node!(html "abc" ; attr!("a","a")),
-                   Node::new(NodeId(id!(html "abc"), None),
-                             vec![attr!("a","a")]));
-        assert_eq!(node!("abc" ; attr!("a","a"),attr!("a","a")),
-                   Node::new(NodeId(id!( "abc"), None),
-                             vec![attr!("a","a"), attr!("a","a")]))
+        assert_eq!(
+            node!(html "abc"; attr!("a","a")),
+            Node::new(NodeId(id!(html "abc"), None), vec![attr!("a", "a")])
+        );
+        assert_eq!(
+            node!(html "abc" ; attr!("a","a")),
+            Node::new(NodeId(id!(html "abc"), None), vec![attr!("a", "a")])
+        );
+        assert_eq!(
+            node!("abc" ; attr!("a","a"),attr!("a","a")),
+            Node::new(
+                NodeId(id!("abc"), None),
+                vec![attr!("a", "a"), attr!("a", "a")]
+            )
+        )
     }
 
     #[test]
     fn attr_test() {
-        assert_eq!(attr!("a","1"), Attribute(id!("a"), id!("1")));
+        assert_eq!(attr!("a", "1"), Attribute(id!("a"), id!("1")));
         assert_eq!(attr!(html "a","1"), Attribute(id!(html "a"), id!("1")))
     }
 

--- a/dot-structures/src/lib.rs
+++ b/dot-structures/src/lib.rs
@@ -69,7 +69,7 @@ impl GraphAttributes {
             "graph" => GraphAttributes::Graph(attrs),
             "node" => GraphAttributes::Node(attrs),
             "edge" => GraphAttributes::Edge(attrs),
-            _ => panic!("only graph, node, edge is applied here. ")
+            _ => panic!("only graph, node, edge is applied here. "),
         }
     }
 }
@@ -186,15 +186,23 @@ impl From<Subgraph> for Vertex {
 /// the component represents a graph in the lang.
 #[derive(Debug, PartialEq, Clone)]
 pub enum Graph {
-    Graph { id: Id, strict: bool, stmts: Vec<Stmt> },
-    DiGraph { id: Id, strict: bool, stmts: Vec<Stmt> },
+    Graph {
+        id: Id,
+        strict: bool,
+        stmts: Vec<Stmt>,
+    },
+    DiGraph {
+        id: Id,
+        strict: bool,
+        stmts: Vec<Stmt>,
+    },
 }
 
 impl Graph {
     pub fn add_stmt(&mut self, stmt: Stmt) {
         match self {
-            Graph::Graph { stmts, .. } => { stmts.push(stmt) }
-            Graph::DiGraph { stmts, .. } => { stmts.push(stmt) }
+            Graph::Graph { stmts, .. } => stmts.push(stmt),
+            Graph::DiGraph { stmts, .. } => stmts.push(stmt),
         }
     }
 }

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,29 @@
+{
+  "json": {},
+  "markdown": {},
+  "toml": {},
+  "rustfmt": {
+    "tab_spaces": "4",
+    "imports_granularity": "Crate",
+    "reorder_imports": true,
+    "group_imports": "StdExternalCrate",
+    "use_field_init_shorthand": true,
+    "normalize_doc_attributes": true,
+    "format_code_in_doc_comments": true,
+    "format_macro_matchers": true,
+    "use_try_shorthand": true
+  },
+  "includes": [
+    "**/*.{json,md,toml,rs}"
+  ],
+  "excludes": [
+    "*lock*",
+    "**/target/"
+  ],
+  "plugins": [
+    "https://plugins.dprint.dev/json-0.16.0.wasm",
+    "https://plugins.dprint.dev/markdown-0.14.3.wasm",
+    "https://plugins.dprint.dev/toml-0.5.4.wasm",
+    "https://plugins.dprint.dev/rustfmt-0.6.2.json@886c6f3161cf020c2d75160262b0f56d74a521e05cfb91ec4f956650c8ca76ca"
+  ]
+}

--- a/into-attr-derive/Cargo.toml
+++ b/into-attr-derive/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-syn = "1.0"
+dot-generator = { path = "../dot-generator", version = "0.2.0" }
+dot-structures = { path = "../dot-structures", version = "0.1.0" }
+into-attr = { path = "../into-attr", version = "0.1.0" }
 quote = "1.0"
-dot-structures = { path = "../dot-structures", version="0.1.0"}
-dot-generator = { path = "../dot-generator" , version="0.2.0"}
-into-attr = {path = "../into-attr", version="0.1.0"}
+syn = "1.0"

--- a/into-attr-derive/src/lib.rs
+++ b/into-attr-derive/src/lib.rs
@@ -1,12 +1,11 @@
-extern crate proc_macro;
 extern crate dot_structures;
+extern crate proc_macro;
 
 use dot_generator::attr;
-use syn::Data;
 use into_attr::IntoAttribute;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn;
+use syn::{self, Data};
 
 #[proc_macro_derive(IntoAttribute)]
 pub fn into_attr_derive(input: TokenStream) -> TokenStream {
@@ -37,11 +36,9 @@ fn impl_into_attr_macro(ast: &syn::DeriveInput) -> TokenStream {
                 }
               }
             }
-
         }
         _ => panic!("the unions are unexpected"),
     };
 
     gen.into()
 }
-

--- a/into-attr/src/lib.rs
+++ b/into-attr/src/lib.rs
@@ -1,4 +1,4 @@
 use dot_structures::Attribute;
-pub trait IntoAttribute{
+pub trait IntoAttribute {
     fn into_attr(self) -> Attribute;
 }

--- a/src/attributes/generate.rs
+++ b/src/attributes/generate.rs
@@ -1,5 +1,9 @@
 #[macro_export]
-macro_rules! as_item { ($i:item) => {$i} }
+macro_rules! as_item {
+    ($i:item) => {
+        $i
+    };
+}
 
 #[macro_export]
 macro_rules! generate_attr {

--- a/src/attributes/mod.rs
+++ b/src/attributes/mod.rs
@@ -3,35 +3,37 @@
 //! [`attributes`]: https://graphviz.org/doc/info/attrs.html
 //! # Examples:
 //! ```rust
+//! use dot_generator::*;
+//! use dot_structures::*;
 //! use graphviz_rust::attributes::{color, color_name, GraphAttributes, NodeAttributes};
 //! use into_attr::IntoAttribute;
-//! use dot_structures::*;
-//! use dot_generator::*;
 //! fn test() {
-//!         assert_eq!(GraphAttributes::center(true), attr!("center",true));
-//!         assert_eq!(
-//!             NodeAttributes::color(color_name::antiquewhite1),
-//!             attr!("color","antiquewhite1"));
-//!         assert_eq!(color::default().into_attr(), attr!("color","black"));
-//!     }
+//!     assert_eq!(GraphAttributes::center(true), attr!("center", true));
+//!     assert_eq!(
+//!         NodeAttributes::color(color_name::antiquewhite1),
+//!         attr!("color", "antiquewhite1")
+//!     );
+//!     assert_eq!(color::default().into_attr(), attr!("color", "black"));
+//! }
 //! ```
 mod generate;
-use crate::{generate_attr, as_item};
-use into_attr::IntoAttribute;
-use into_attr_derive::IntoAttribute;
+use std::fmt::{Display, Formatter};
+
 use dot_generator::{attr, id};
 use dot_structures::*;
-use std::fmt::Display;
-use std::fmt::Formatter;
+use into_attr::IntoAttribute;
+use into_attr_derive::IntoAttribute;
+
+use crate::{as_item, generate_attr};
 
 /// The attributes appearing on the node
-pub enum  NodeAttributes {}
+pub enum NodeAttributes {}
 /// The attributes appearing on the edge
-pub enum  EdgeAttributes {}
+pub enum EdgeAttributes {}
 /// The attributes appearing on the root graph
-pub enum  GraphAttributes {}
+pub enum GraphAttributes {}
 /// The attributes appearing on the subgraph
-pub enum  SubgraphAttributes {}
+pub enum SubgraphAttributes {}
 
 generate_attr!(struct _background for GraphAttributes; String; "<none>".to_string() );
 generate_attr!(struct area for NodeAttributes, SubgraphAttributes; f32; 1.0);
@@ -302,22 +304,22 @@ generate_attr!(enum color_name;
     //endregion
 );
 
-
-
-
-
 #[cfg(test)]
 pub mod tests {
     use std::fmt::{Display, Formatter};
-    use dot_generator::{attr};
-    use crate::attributes::*;
+
+    use dot_generator::attr;
     use into_attr::IntoAttribute;
 
+    use crate::attributes::*;
 
     #[test]
     fn test() {
-        assert_eq!(GraphAttributes::center(true), attr!("center",true));
-        assert_eq!(GraphAttributes::bgcolor(color_name::antiquewhite1), attr!("bgcolor","antiquewhite1"));
-        assert_eq!(color::default().into_attr(), attr!("color","black"));
+        assert_eq!(GraphAttributes::center(true), attr!("center", true));
+        assert_eq!(
+            GraphAttributes::bgcolor(color_name::antiquewhite1),
+            attr!("bgcolor", "antiquewhite1")
+        );
+        assert_eq!(color::default().into_attr(), attr!("color", "black"));
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -43,9 +43,12 @@
 //!
 //!  }
 //! ```
+use std::{
+    io::{self, Write},
+    process::{Command, Output},
+};
+
 use tempfile::NamedTempFile;
-use std::io::{self, Write};
-use std::process::{Command, Output};
 
 pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<String> {
     let args = args.into_iter().map(|a| a.prepare()).collect();
@@ -61,22 +64,18 @@ pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<String> {
     })
 }
 
-
 fn do_exec(input: String, args: Vec<String>) -> io::Result<Output> {
     let mut command = Command::new("dot");
 
     for arg in args {
         command.arg(arg);
     }
-    command
-        .arg(input)
-        .output()
+    command.arg(input).output()
 }
 
 fn temp_file(ctx: String) -> io::Result<NamedTempFile> {
     let mut file = NamedTempFile::new()?;
-    file.write_all(ctx.as_bytes())
-        .map(|_x| file)
+    file.write_all(ctx.as_bytes()).map(|_x| file)
 }
 
 /// Command arguments that can be passed to exec.
@@ -115,7 +114,7 @@ impl CommandArg {
                     Format::DotJson => "dot_json".to_string(),
                     Format::XdotJson => "xdot_json".to_string(),
                     Format::PlainExt => "plain-ext".to_string(),
-                    _ => format!("{:?}", f).to_lowercase()
+                    _ => format!("{:?}", f).to_lowercase(),
                 };
                 format!("-T{}", str)
             }
@@ -123,7 +122,7 @@ impl CommandArg {
     }
 }
 
-#[derive(Debug,Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum Layout {
     Dot,
     Neato,
@@ -135,8 +134,7 @@ pub enum Layout {
     Sfdp,
 }
 
-
-#[derive(Debug,Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub enum Format {
     Bmp,
     Cgimage,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,6 @@
 //! [`graphviz`]: https://graphviz.org/
 //! [`notation`]: https://graphviz.org/doc/info/lang.html
 //! [`execute`]: https://graphviz.org/doc/info/command.html
-//!
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 pub extern crate dot_generator;
@@ -107,14 +106,18 @@ pub extern crate into_attr;
 pub extern crate into_attr_derive;
 
 use std::io;
+
 use dot_structures::*;
-use crate::cmd::CommandArg;
-use crate::printer::{DotPrinter, PrinterContext};
+
+use crate::{
+    cmd::CommandArg,
+    printer::{DotPrinter, PrinterContext},
+};
 
 pub mod attributes;
-pub mod printer;
 pub mod cmd;
 mod parser;
+pub mod printer;
 
 #[macro_use]
 extern crate pest_derive;
@@ -143,19 +146,26 @@ pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<String> 
 
 #[cfg(test)]
 mod tests {
-    use std::fs;
-    use std::path::{Path, PathBuf};
-    use std::process::Command;
-    use dot_structures::*;
+    use std::{
+        fs,
+        path::{Path, PathBuf},
+        process::Command,
+    };
+
     use dot_generator::*;
-    use crate::attributes::*;
-    use crate::{exec, exec_dot, parse};
-    use crate::cmd::{CommandArg, Format};
-    use crate::printer::{DotPrinter, PrinterContext};
+    use dot_structures::*;
+
+    use crate::{
+        attributes::*,
+        cmd::{CommandArg, Format},
+        exec, exec_dot, parse,
+        printer::{DotPrinter, PrinterContext},
+    };
 
     #[test]
     fn parse_test() {
-        let g: Graph = parse(r#"
+        let g: Graph = parse(
+            r#"
         strict digraph t {
             aa[color=green]
             subgraph v {
@@ -167,7 +177,9 @@ mod tests {
             aa -> be -> subgraph v { d -> aaa}
             aa -> aaa -> v
         }
-        "#).unwrap();
+        "#,
+        )
+        .unwrap();
 
         assert_eq!(
             g,
@@ -228,24 +240,24 @@ mod tests {
             .expect("dot command failed to start");
 
         let output = String::from_utf8_lossy(&child.stderr);
-        let version =
-            output
-                .strip_prefix("dot - ")
-                .and_then(|v| v.strip_suffix(LS))
-                .expect("the version of client is unrecognizable ");
+        let version = output
+            .strip_prefix("dot - ")
+            .and_then(|v| v.strip_suffix(LS))
+            .expect("the version of client is unrecognizable ");
         println!("{}", version);
 
-        let out_svg = exec(g.clone(), &mut ctx, vec![
-            CommandArg::Format(Format::Svg),
-        ]).unwrap();
-
+        let out_svg = exec(g.clone(), &mut ctx, vec![CommandArg::Format(Format::Svg)]).unwrap();
 
         let p = "1.svg";
-        let out = exec(g.clone(), &mut PrinterContext::default(), vec![
-            CommandArg::Format(Format::Svg),
-            CommandArg::Output(p.to_string()),
-        ]).unwrap();
-
+        let out = exec(
+            g.clone(),
+            &mut PrinterContext::default(),
+            vec![
+                CommandArg::Format(Format::Svg),
+                CommandArg::Output(p.to_string()),
+            ],
+        )
+        .unwrap();
 
         let file = fs::read_to_string(p).unwrap();
 
@@ -257,26 +269,21 @@ mod tests {
     #[test]
     fn output_exec_from_test() {
         let mut g = graph!(id!("id");
-                node!("nod"),
-                subgraph!("sb";
-                    edge!(node_id!("a") => subgraph!(;
-                       node!("n";
-                       NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
-                   ))
-               ),
-               edge!(node_id!("a1") => node_id!(esc "a2"))
-           );
+             node!("nod"),
+             subgraph!("sb";
+                 edge!(node_id!("a") => subgraph!(;
+                    node!("n";
+                    NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
+                ))
+            ),
+            edge!(node_id!("a1") => node_id!(esc "a2"))
+        );
         let dot = g.print(&mut PrinterContext::default());
         let format = Format::Svg;
 
-        let res1 = exec_dot(dot.clone(), vec![
-            CommandArg::Format(format),
-        ]).unwrap();
-        let res2 = exec_dot(dot.clone(), vec![
-            CommandArg::Format(format.clone()),
-        ]).unwrap();
+        let res1 = exec_dot(dot.clone(), vec![CommandArg::Format(format)]).unwrap();
+        let res2 = exec_dot(dot.clone(), vec![CommandArg::Format(format.clone())]).unwrap();
 
         assert_eq!(res1, res2)
     }
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,89 +10,94 @@
 //!
 //! # Examples:
 //! ```rust
-//! use dot_structures::*;
 //! use dot_generator::*;
-//! use graphviz_rust::{exec,parse, exec_dot};
-//! use graphviz_rust::cmd::{CommandArg, Format};
-//! use graphviz_rust::printer::{PrinterContext,DotPrinter};
-//! use graphviz_rust::attributes::*;
+//! use dot_structures::*;
+//! use graphviz_rust::{
+//!     attributes::*,
+//!     cmd::{CommandArg, Format},
+//!     exec, exec_dot, parse,
+//!     printer::{DotPrinter, PrinterContext},
+//! };
 //!
 //! fn parse_test() {
-//!        let g: Graph = parse(r#"
-//!        strict digraph t {
-//!            aa[color=green]
-//!            subgraph v {
-//!                aa[shape=square]
-//!                subgraph vv{a2 -> b2}
-//!                aaa[color=red]
-//!                aaa -> bbb
-//!            }
-//!            aa -> be -> subgraph v { d -> aaa}
-//!            aa -> aaa -> v
-//!        }
-//!        "#).unwrap();
+//!     let g: Graph = parse(
+//!         r#"
+//!         strict digraph t {
+//!             aa[color=green]
+//!             subgraph v {
+//!                 aa[shape=square]
+//!                 subgraph vv{a2 -> b2}
+//!                 aaa[color=red]
+//!                 aaa -> bbb
+//!             }
+//!             aa -> be -> subgraph v { d -> aaa}
+//!             aa -> aaa -> v
+//!         }
+//!         "#,
+//!     )
+//!     .unwrap();
 //!
-//!        assert_eq!(
-//!            g,
-//!            graph!(strict di id!("t");
-//!              node!("aa";attr!("color","green")),
-//!              subgraph!("v";
-//!                node!("aa"; attr!("shape","square")),
-//!                subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
-//!                node!("aaa";attr!("color","red")),
-//!                edge!(node_id!("aaa") => node_id!("bbb"))
-//!                ),
-//!              edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
-//!              edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
-//!            )
-//!        )
-//!    }
+//!     assert_eq!(
+//!         g,
+//!         graph!(strict di id!("t");
+//!           node!("aa";attr!("color","green")),
+//!           subgraph!("v";
+//!             node!("aa"; attr!("shape","square")),
+//!             subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
+//!             node!("aaa";attr!("color","red")),
+//!             edge!(node_id!("aaa") => node_id!("bbb"))
+//!             ),
+//!           edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
+//!           edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+//!         )
+//!     )
+//! }
 //!
 //! fn print_test() {
-//!        let mut g = graph!(strict di id!("id"));
-//!        assert_eq!("strict digraph id {}".to_string(), g.print(&mut PrinterContext::default()));
-//!    }
+//!     let mut g = graph!(strict di id!("id"));
+//!     assert_eq!(
+//!         "strict digraph id {}".to_string(),
+//!         g.print(&mut PrinterContext::default())
+//!     );
+//! }
 //!
-//!  fn output_test(){
+//! fn output_test() {
 //!     let mut g = graph!(id!("id");
-//!             node!("nod"),
-//!             subgraph!("sb";
-//!                 edge!(node_id!("a") => subgraph!(;
-//!                    node!("n";
-//!                    NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
-//!                ))
-//!            ),
-//!            edge!(node_id!("a1") => node_id!(esc "a2"))
-//!        );
-//!        let graph_svg = exec(g, &mut PrinterContext::default(), vec![
-//!            CommandArg::Format(Format::Svg),
-//!        ]).unwrap();
-//!
-//!  }
-//!  fn output_exec_from_test(){
+//!          node!("nod"),
+//!          subgraph!("sb";
+//!              edge!(node_id!("a") => subgraph!(;
+//!                 node!("n";
+//!                 NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
+//!             ))
+//!         ),
+//!         edge!(node_id!("a1") => node_id!(esc "a2"))
+//!     );
+//!     let graph_svg = exec(
+//!         g,
+//!         &mut PrinterContext::default(),
+//!         vec![CommandArg::Format(Format::Svg)],
+//!     )
+//!     .unwrap();
+//! }
+//! fn output_exec_from_test() {
 //!     let mut g = graph!(id!("id");
-//!             node!("nod"),
-//!             subgraph!("sb";
-//!                 edge!(node_id!("a") => subgraph!(;
-//!                    node!("n";
-//!                    NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
-//!                ))
-//!            ),
-//!            edge!(node_id!("a1") => node_id!(esc "a2"))
-//!        );
-//!        let dot = g.print(&mut PrinterContext::default());
-//!        println!("{}",dot);
-//!        let  format = Format::Svg;
+//!          node!("nod"),
+//!          subgraph!("sb";
+//!              edge!(node_id!("a") => subgraph!(;
+//!                 node!("n";
+//!                 NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
+//!             ))
+//!         ),
+//!         edge!(node_id!("a1") => node_id!(esc "a2"))
+//!     );
+//!     let dot = g.print(&mut PrinterContext::default());
+//!     println!("{}", dot);
+//!     let format = Format::Svg;
 //!
-//!        let graph_svg = exec_dot(dot.clone(), vec![
-//!            CommandArg::Format(format),
-//!        ]).unwrap();
+//!     let graph_svg = exec_dot(dot.clone(), vec![CommandArg::Format(format)]).unwrap();
 //!
-//!         let graph_svg = exec_dot(dot, vec![
-//!            CommandArg::Format(format.clone()),
-//!        ]).unwrap();
-//!
-//!  }
+//!     let graph_svg = exec_dot(dot, vec![CommandArg::Format(format.clone())]).unwrap();
+//! }
 //! ```
 //!
 //! [`graphviz`]: https://graphviz.org/

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -12,18 +12,20 @@
 //!         assert_eq!(s.print(&mut ctx), "subgraph id {\n    abc\n    a -- b \n}".to_string());
 //!     }
 //! ```
-use dot_structures::{Attribute, Edge, EdgeTy, Graph, GraphAttributes, Id, Node, NodeId, Port, Stmt, Subgraph, Vertex};
+use dot_structures::{
+    Attribute, Edge, EdgeTy, Graph, GraphAttributes, Id, Node, NodeId, Port, Stmt, Subgraph, Vertex,
+};
 
 /// Context allows to customize the output of the file.
 /// # Example:
 /// ```rust
-///     fn ctx(){
-///         use self::graphviz_rust::printer::PrinterContext;
+/// fn ctx() {
+///     use self::graphviz_rust::printer::PrinterContext;
 ///
-///         let mut ctx =PrinterContext::default();
-///         ctx.always_inline();
-///         ctx.with_indent_step(4);
-///     }
+///     let mut ctx = PrinterContext::default();
+///     ctx.always_inline();
+///     ctx.with_indent_step(4);
+/// }
 /// ```
 pub struct PrinterContext {
     /// internal flag which is decoupled from the graph
@@ -87,16 +89,26 @@ impl PrinterContext {
 
 impl PrinterContext {
     fn indent(&self) -> String {
-        if self.is_inline_on() { "".to_string() } else { " ".repeat(self.indent) }
+        if self.is_inline_on() {
+            "".to_string()
+        } else {
+            " ".repeat(self.indent)
+        }
     }
     fn indent_grow(&mut self) {
-        if !self.is_inline_on() { self.indent += self.indent_step }
+        if !self.is_inline_on() {
+            self.indent += self.indent_step
+        }
     }
     fn indent_shrink(&mut self) {
-        if !self.is_inline_on() { self.indent -= self.indent_step }
+        if !self.is_inline_on() {
+            self.indent -= self.indent_step
+        }
     }
 
-    fn is_inline_on(&self) -> bool { self.l_s == self.l_s_i }
+    fn is_inline_on(&self) -> bool {
+        self.l_s == self.l_s_i
+    }
     fn inline_mode(&mut self) {
         self.l_s = self.l_s_i.clone()
     }
@@ -156,7 +168,7 @@ impl DotPrinter for Port {
             Port(Some(id), Some(d)) => format!(":{}:{}", id.print(ctx), d),
             Port(None, Some(d)) => format!(":{}", d),
             Port(Some(id), None) => format!(":{}", id.print(ctx)),
-            _ => unreachable!("")
+            _ => unreachable!(""),
         }
     }
 }
@@ -165,7 +177,7 @@ impl DotPrinter for NodeId {
     fn print(&self, ctx: &mut PrinterContext) -> String {
         match self {
             NodeId(id, None) => id.print(ctx),
-            NodeId(id, Some(port)) => [id.print(ctx), port.print(ctx)].join("")
+            NodeId(id, Some(port)) => [id.print(ctx), port.print(ctx)].join(""),
         }
     }
 }
@@ -173,7 +185,7 @@ impl DotPrinter for NodeId {
 impl DotPrinter for Attribute {
     fn print(&self, ctx: &mut PrinterContext) -> String {
         match self {
-            Attribute(l, r) => format!("{}={}", l.print(ctx), r.print(ctx))
+            Attribute(l, r) => format!("{}={}", l.print(ctx), r.print(ctx)),
         }
     }
 }
@@ -181,7 +193,9 @@ impl DotPrinter for Attribute {
 impl DotPrinter for Vec<Attribute> {
     fn print(&self, ctx: &mut PrinterContext) -> String {
         let attrs: Vec<String> = self.iter().map(|e| e.print(ctx)).collect();
-        if attrs.is_empty() { "".to_string() } else {
+        if attrs.is_empty() {
+            "".to_string()
+        } else {
             format!("[{}]", attrs.join(","))
         }
     }
@@ -231,9 +245,19 @@ impl DotPrinter for Graph {
             Graph::Graph { id, strict, stmts } if *strict => {
                 ctx.is_digraph = false;
                 let body = stmts.print(ctx);
-                format!("strict graph {} {{{}{}{}}}", id.print(ctx), ctx.l_s, body, ctx.l_s)
+                format!(
+                    "strict graph {} {{{}{}{}}}",
+                    id.print(ctx),
+                    ctx.l_s,
+                    body,
+                    ctx.l_s
+                )
             }
-            Graph::Graph { id, strict:_, stmts } => {
+            Graph::Graph {
+                id,
+                strict: _,
+                stmts,
+            } => {
                 ctx.is_digraph = false;
                 let body = stmts.print(ctx);
                 format!("graph {} {{{}{}{}}}", id.print(ctx), ctx.l_s, body, ctx.l_s)
@@ -241,12 +265,28 @@ impl DotPrinter for Graph {
             Graph::DiGraph { id, strict, stmts } if *strict => {
                 ctx.is_digraph = true;
                 let body = stmts.print(ctx);
-                format!("strict digraph {} {{{}{}{}}}", id.print(ctx), ctx.l_s, body, ctx.l_s)
+                format!(
+                    "strict digraph {} {{{}{}{}}}",
+                    id.print(ctx),
+                    ctx.l_s,
+                    body,
+                    ctx.l_s
+                )
             }
-            Graph::DiGraph { id, strict:_, stmts } => {
+            Graph::DiGraph {
+                id,
+                strict: _,
+                stmts,
+            } => {
                 ctx.is_digraph = true;
                 let body = stmts.print(ctx);
-                format!("digraph {} {{{}{}{}}}", id.print(ctx), ctx.l_s, body, ctx.l_s)
+                format!(
+                    "digraph {} {{{}{}{}}}",
+                    id.print(ctx),
+                    ctx.l_s,
+                    body,
+                    ctx.l_s
+                )
             }
         }
     }
@@ -278,10 +318,22 @@ impl DotPrinter for Stmt {
 fn print_edge(edge: &Edge, ctx: &mut PrinterContext) -> String {
     let bond = if ctx.is_digraph { "->" } else { "--" };
     match edge {
-        Edge { ty: EdgeTy::Pair(l, r), attributes } => {
-            format!("{} {} {} {}", l.print(ctx), bond, r.print(ctx), attributes.print(ctx))
+        Edge {
+            ty: EdgeTy::Pair(l, r),
+            attributes,
+        } => {
+            format!(
+                "{} {} {} {}",
+                l.print(ctx),
+                bond,
+                r.print(ctx),
+                attributes.print(ctx)
+            )
         }
-        Edge { ty: EdgeTy::Chain(vs), attributes } => {
+        Edge {
+            ty: EdgeTy::Chain(vs),
+            attributes,
+        } => {
             let mut iter = vs.iter();
             let h = iter.next().unwrap().print(ctx);
             let mut chain = h;
@@ -308,8 +360,9 @@ impl DotPrinter for Edge {
 
 #[cfg(test)]
 mod tests {
-    use dot_generator::{id, port, attr, node, stmt, subgraph, graph, edge, node_id};
+    use dot_generator::{attr, edge, graph, id, node, node_id, port, stmt, subgraph};
     use dot_structures::*;
+
     use crate::printer::{DotPrinter, PrinterContext};
 
     #[test]
@@ -323,7 +376,7 @@ mod tests {
 
     #[test]
     fn node_id_test() {
-        let node_id = NodeId(id!("abc"), Some(port!( id!("abc"), "n" )));
+        let node_id = NodeId(id!("abc"), Some(port!(id!("abc"), "n")));
         let mut ctx = PrinterContext::default();
         assert_eq!(node_id.print(&mut ctx), "abc:abc:n".to_string());
     }
@@ -331,20 +384,23 @@ mod tests {
     #[test]
     fn node_test() {
         let mut ctx = PrinterContext::default();
-        assert_eq!(node!("abc";attr!("a",2)).print(&mut ctx), "abc[a=2]".to_string());
+        assert_eq!(
+            node!("abc";attr!("a",2)).print(&mut ctx),
+            "abc[a=2]".to_string()
+        );
     }
 
     #[test]
     fn attr_test() {
         let mut ctx = PrinterContext::default();
-        let attr = attr!("a",2);
+        let attr = attr!("a", 2);
         assert_eq!(attr.print(&mut ctx), "a=2".to_string());
     }
 
     #[test]
     fn graph_attr_test() {
         let mut ctx = PrinterContext::default();
-        let n_attr = GraphAttributes::Node(vec![attr!("a",2), attr!("b",3)]);
+        let n_attr = GraphAttributes::Node(vec![attr!("a", 2), attr!("b", 3)]);
         assert_eq!(n_attr.print(&mut ctx), "node[a=2,b=3]".to_string());
     }
 
@@ -353,7 +409,10 @@ mod tests {
         let mut ctx = PrinterContext::default();
         let s = subgraph!("id"; node!("abc"), edge!(node_id!("a") => node_id!("b")));
         println!("{}", s.print(&mut ctx));
-        assert_eq!(s.print(&mut ctx), "subgraph id {\n    abc\n    a -- b \n}".to_string());
+        assert_eq!(
+            s.print(&mut ctx),
+            "subgraph id {\n    abc\n    a -- b \n}".to_string()
+        );
     }
 
     #[test]
@@ -361,16 +420,19 @@ mod tests {
         let mut ctx = PrinterContext::default();
         ctx.always_inline();
         let g = graph!(strict di id!("t");
-              node!("aa";attr!("color","green")),
-              subgraph!("v";
-                node!("aa"; attr!("shape","square")),
-                subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
-                node!("aaa";attr!("color","red")),
-                edge!(node_id!("aaa") => node_id!("bbb"))
-                ),
-              edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
-              edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
-            );
-        assert_eq!(r#"strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2 }aaa[color=red]aaa -> bbb }aa -> be -> subgraph v {d -> aaa }aa -> aaa -> v}"#, g.print(&mut ctx));
+          node!("aa";attr!("color","green")),
+          subgraph!("v";
+            node!("aa"; attr!("shape","square")),
+            subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),
+            node!("aaa";attr!("color","red")),
+            edge!(node_id!("aaa") => node_id!("bbb"))
+            ),
+          edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
+          edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+        );
+        assert_eq!(
+            r#"strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2 }aaa[color=red]aaa -> bbb }aa -> be -> subgraph v {d -> aaa }aa -> aaa -> v}"#,
+            g.print(&mut ctx)
+        );
     }
 }


### PR DESCRIPTION
This fixes the inconsistent formatting in the code and the documentation via [dprint](https://dprint.dev/)


Before this, the documentation and code had inconsistent indentation that made the code hard to read. As an example:
https://lib.rs/crates/dot-generator

The commits are separated. The [first commit](https://github.com/besok/graphviz-rust/pull/11/commits/9ee7ab90134771eeadaa1ce918422bb3b16ab109) adds the dprint config, and the second commit is fully automated and runs `dprint fmt`. No functional code changes have been made.