### PR TITLE
Fix escaped attr parsing

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -36,7 +36,7 @@
 //!         let mut g = graph!(id!("id"));
 //!         let mut ctx = PrinterContext::default();
 //!         ctx.always_inline();
-//!         let empty = exec(g.print(&mut ctx), vec![
+//!         let empty = exec(g, &mut ctx, vec![
 //!            CommandArg::Format(Format::Svg),
 //!            CommandArg::Output("1.svg".to_string())
 //!        ]);

--- a/src/grammar/dot.pest
+++ b/src/grammar/dot.pest
@@ -1,10 +1,12 @@
 WHITESPACE = _{ " " | "\t" | "\r\n" | "\n" }
 COMMENT    = _{("/*" ~ (!"*/" ~ ANY)* ~ "*/") | (("#" | "//") ~ (!NEWLINE ~ ANY)* ~ NEWLINE?) }
-word = _{ ('a'..'z' | 'A'..'Z')+ }
+word = _{ ('a'..'z' | 'A'..'Z' | "_")+ }
 arr = _{"->" | "--"}
 char = _{
     !("\"" | "\\" | "\'") ~ ANY
     | "\\" ~ ("\"" | "\'" |  "\\" | "/" | "b" | "f" | "n" | "r" | "t")
+    // TODO: the following option is only valid for some attributes: https://graphviz.org/docs/attr-types/escString/
+    | "\\" ~ ("G" | "N" | "E" | "H" | "T" | "L")
     | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
 }
 
@@ -12,7 +14,7 @@ inner = ${ char* }
 number = ${"-"? ~ (("0" | ASCII_NONZERO_DIGIT ~ ASCII_DIGIT*) ~ ("." ~ ASCII_DIGIT+)? | ("." ~ ASCII_DIGIT+))}
 string_qt = ${ "\"" ~ inner ~ "\"" }
 html = ${"<" ~ (!(">" ~ WHITESPACE* ~">") ~ ANY)+ ~ ">" ~ WHITESPACE* ~ ">"}
-plain = ${(word ~ (word | ASCII_DIGIT | "_")*) | number}
+plain = ${(word ~ (word | ASCII_DIGIT)*) | number}
 
 
 compass = ${"n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw" | "c" | "_"}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -512,10 +512,10 @@ mod test {
         strict digraph t {
             aa[color=green]
             subgraph v {
-	            aa[shape=square]
-	            subgraph vv{a2 -> b2}
-	            aaa[color=red]
-	            aaa -> bbb
+                aa[shape=square]
+                subgraph vv{a2 -> b2}
+                aaa[color=red]
+                aaa -> bbb
             }
             aa -> be -> subgraph v { d -> aaa}
             aa -> aaa -> v
@@ -536,6 +536,29 @@ mod test {
                 ),
               edge!(node_id!("aa") => node_id!("be") => subgraph!("v"; edge!(node_id!("d") => node_id!("aaa")))),
               edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
+            )
+        )
+    }
+
+    #[test]
+    fn global_attr_test() {
+        let g: Graph = parse(
+            r#"
+        graph t {
+            graph [bb="0,0,54,108"];
+            node [label="\N"];
+            a -- b;
+        }
+        "#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            g,
+            graph!(id!("t");
+                stmt!(GraphAttributes::Graph(vec![attr!("bb", esc "0,0,54,108")])),
+                stmt!(GraphAttributes::Node(vec![attr!("label", esc "\\N")])),
+                edge!(node_id!("a") => node_id!("b"))
             )
         )
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -545,7 +545,7 @@ mod test {
         let g: Graph = parse(
             r#"
         graph t {
-            graph [bb="0,0,54,108"];
+            graph [_draw_="c 9 "];
             node [label="\N"];
             a -- b;
         }
@@ -556,7 +556,7 @@ mod test {
         assert_eq!(
             g,
             graph!(id!("t");
-                stmt!(GraphAttributes::Graph(vec![attr!("bb", esc "0,0,54,108")])),
+                stmt!(GraphAttributes::Graph(vec![attr!("_draw_", esc "c 9 ")])),
                 stmt!(GraphAttributes::Node(vec![attr!("label", esc "\\N")])),
                 edge!(node_id!("a") => node_id!("b"))
             )


### PR DESCRIPTION
Implements

- [`escString`](https://graphviz.org/docs/attr-types/escString/) attribute values (such as the default node label `"\N"`) and
- attribute names starting with `_` (such as [`_background`](https://graphviz.org/docs/attrs/background/))

and adds a test for both

Fixes #14