### PR TITLE
Any character except an unescaped " is a valid character in a double-quoted ID

### DIFF
--- a/src/grammar/dot.pest
+++ b/src/grammar/dot.pest
@@ -2,12 +2,9 @@ WHITESPACE = _{ " " | "\t" | "\r\n" | "\n" }
 COMMENT    = _{("/*" ~ (!"*/" ~ ANY)* ~ "*/") | (("#" | "//") ~ (!NEWLINE ~ ANY)* ~ NEWLINE?) }
 word = _{ ('a'..'z' | 'A'..'Z' | "_")+ }
 arr = _{"->" | "--"}
-char = _{
-    !("\"" | "\\" | "\'") ~ ANY
-    | "\\" ~ ("\"" | "\'" |  "\\" | "/" | "b" | "f" | "n" | "r" | "t")
-    // TODO: the following option is only valid for some attributes: https://graphviz.org/docs/attr-types/escString/
-    | "\\" ~ ("G" | "N" | "E" | "H" | "T" | "L")
-    | "\\" ~ ("u" ~ ASCII_HEX_DIGIT{4})
+char = {
+    !("\"" | "\\") ~ ANY
+    | "\\" ~ (ANY)
 }
 
 inner = ${ char* }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -246,6 +246,14 @@ mod test {
         let result = process_id(_parse("abc_a", Rule::id));
         assert_eq!(result, id!("abc_a"));
 
+        // valid ID
+        let result = process_id(_parse(r#""a\b\c.'\"""#, Rule::id));
+        assert_eq!(result, id!(esc r#"a\b\c.'\""#));
+
+        // invalid ID unescaped quote
+        let result = process_id(_parse(r#""a\b"\c.'\"""#, Rule::id));
+        assert_eq!(result, id!(esc r#"a\b"#));
+
         let result = process_id(_parse("\"ab\\\"c\"", Rule::id));
         assert_eq!(result, id!(esc "ab\\\"c"));
 
@@ -510,7 +518,7 @@ mod test {
         let g: Graph = parse(
             r#"
         strict digraph t {
-            aa[color=green]
+            aa[color=green,label="shouln't er\ror"]
             subgraph v {
                 aa[shape=square]
                 subgraph vv{a2 -> b2}
@@ -527,7 +535,7 @@ mod test {
         assert_eq!(
             g,
             graph!(strict di id!("t");
-              node!("aa";attr!("color","green")),
+              node!("aa";attr!("color","green"),attr!("label", esc "shouln't er\\ror")),
               subgraph!("v";
                 node!("aa"; attr!("shape","square")),
                 subgraph!("vv"; edge!(node_id!("a2") => node_id!("b2"))),


### PR DESCRIPTION
Resolves #21


Works:
```dot
digraph graph_test {
  start [
    label="conte\xt.set('This \\\"sho\uldn\'t\\\" error');
    t\est😁✅"
  ];
  end [
    label="End⛔"
  ];
  start-> end;
}
```

Does not work:
```dot
digraph graph_test {
  start [
    label="conte\xt.set('Thi"s should error');
    t\est😁✅"
  ];
  end [
    label="End⛔"
  ];
  start-> end;
}
```
```
 --> 3:30
  |
3 |     label="conte\xt.set('Thi"s should error');
  |                              ^---
  |
  = expected bare_attr
```
