### PR TITLE
Add more docs

### DIFF
--- a/src/attributes/mod.rs
+++ b/src/attributes/mod.rs
@@ -1,3 +1,4 @@
+#![allow(non_snake_case)]
 //! graphviz [`attributes`]
 //!
 //! [`attributes`]: https://graphviz.org/doc/info/attrs.html
@@ -306,8 +307,6 @@ generate_attr!(enum color_name;
 
 #[cfg(test)]
 pub mod tests {
-    use std::fmt::{Display, Formatter};
-
     use dot_generator::attr;
     use into_attr::IntoAttribute;
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,12 +1,13 @@
-//! It allows to execute cmd engine passing extra parameters
+//! Utilities for executing the [`dot` command line executable].
 //!
-//! *It is important*: to execute it properly it needs to have an [`executable package`] on the system
+//! *Important*: users should have the `dot` command line executable installed.
+//! A download can be found here: https://graphviz.org/download/.
 //!
-//! The extra information can be found in [`layouts`] and [`outputs`]
+//! Additional information on controlling the output can be found in [`layouts`]
+//! and [`outputs`].
 //!
 //! [`layouts`]: https://graphviz.org/docs/layouts/
 //! [`outputs`]:https://graphviz.org/docs/outputs/
-//! [`executable package`]: https://graphviz.org/download/
 //! # Example:
 //! ```no_run
 //!     use dot_structures::*;
@@ -43,6 +44,8 @@
 //!
 //!  }
 //! ```
+//!
+//! [`dot` command line executable]: https://graphviz.org/doc/info/command.html
 use std::{
     io::{self, ErrorKind, Write},
     process::{Command, Output},
@@ -86,7 +89,8 @@ fn temp_file(ctx: String) -> io::Result<NamedTempFile> {
 pub enum CommandArg {
     /// any custom argument.
     ///
-    /// _Note_: it does not manage any prefixes and thus '-' or the prefix must be passed as well.
+    /// _Note_: it does not manage any prefixes and thus '-' or the prefix must
+    /// be passed as well.
     Custom(String),
     /// Regulates the output file with -o prefix
     Output(String),
@@ -135,6 +139,10 @@ impl CommandArg {
     }
 }
 
+/// Various algorithms for projecting abstract graphs into a space for
+/// visualization
+///
+/// https://graphviz.org/docs/layouts/
 #[derive(Debug, Copy, Clone)]
 pub enum Layout {
     Dot,
@@ -147,6 +155,10 @@ pub enum Layout {
     Sfdp,
 }
 
+/// Various graphic and data formats for end user, web, documents and other
+/// applications.
+///
+/// https://graphviz.org/docs/outputs/
 #[derive(Debug, Copy, Clone)]
 pub enum Format {
     Bmp,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,48 +1,47 @@
 //! Utilities for executing the [`dot` command line executable].
 //!
 //! *Important*: users should have the `dot` command line executable installed.
-//! A download can be found here: https://graphviz.org/download/.
+//! A download can be found here: <https://graphviz.org/download/>.
 //!
-//! Additional information on controlling the output can be found in [`layouts`]
-//! and [`outputs`].
+//! Additional information on controlling the output can be found in the `graphviz`
+//! docs on [layouts] and [output formats].
 //!
-//! [`layouts`]: https://graphviz.org/docs/layouts/
-//! [`outputs`]:https://graphviz.org/docs/outputs/
+//! [layouts]: https://graphviz.org/docs/layouts/
+//! [output formats]:https://graphviz.org/docs/outputs/
 //! # Example:
 //! ```no_run
-//!     use dot_structures::*;
-//!     use dot_generator::*;
-//!     use graphviz_rust::attributes::*;
-//!     use graphviz_rust::cmd::{CommandArg, Format};
-//!     use graphviz_rust::exec;
-//!     use graphviz_rust::printer::{PrinterContext,DotPrinter};
+//! use dot_structures::*;
+//! use dot_generator::*;
+//! use graphviz_rust::attributes::*;
+//! use graphviz_rust::cmd::{CommandArg, Format};
+//! use graphviz_rust::exec;
+//! use graphviz_rust::printer::{PrinterContext,DotPrinter};
 //!
-//!  fn graph_to_output(){
+//! fn graph_to_output(){
 //!     let mut g = graph!(id!("id");
 //!             node!("nod"),
 //!             subgraph!("sb";
-//!                 edge!(node_id!("a") => subgraph!(;
-//!                    node!("n";
-//!                    NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
-//!                ))
-//!            ),
-//!            edge!(node_id!("a1") => node_id!(esc "a2"))
-//!        );
-//!        let graph_svg = exec(g, &mut PrinterContext::default(), vec![
-//!            CommandArg::Format(Format::Svg),
-//!        ]).unwrap();
+//!                edge!(node_id!("a") => subgraph!(;
+//!                   node!("n";
+//!                   NodeAttributes::color(color_name::black), NodeAttributes::shape(shape::egg))
+//!               ))
+//!           ),
+//!           edge!(node_id!("a1") => node_id!(esc "a2"))
+//!     );
+//!     let graph_svg = exec(g, &mut PrinterContext::default(), vec![
+//!         CommandArg::Format(Format::Svg),
+//!     ]).unwrap();
+//! }
 //!
-//!  }
-//!  fn graph_to_file(){
-//!         let mut g = graph!(id!("id"));
-//!         let mut ctx = PrinterContext::default();
-//!         ctx.always_inline();
-//!         let empty = exec(g, &mut ctx, vec![
-//!            CommandArg::Format(Format::Svg),
-//!            CommandArg::Output("1.svg".to_string())
-//!        ]);
-//!
-//!  }
+//! fn graph_to_file(){
+//!        let mut g = graph!(id!("id"));
+//!        let mut ctx = PrinterContext::default();
+//!        ctx.always_inline();
+//!        let empty = exec(g, &mut ctx, vec![
+//!           CommandArg::Format(Format::Svg),
+//!           CommandArg::Output("1.svg".to_string())
+//!       ]);
+//! }
 //! ```
 //!
 //! [`dot` command line executable]: https://graphviz.org/doc/info/command.html
@@ -82,10 +81,10 @@ fn temp_file(ctx: String) -> io::Result<NamedTempFile> {
     file.write_all(ctx.as_bytes()).map(|_x| file)
 }
 
-/// Command arguments that can be passed to exec.
-/// The list of possible [`commands`]
+/// Commandline arguments that can be passed to executable.
 ///
-/// [`commands`]:https://graphviz.org/doc/info/command.html
+/// The list of possible commands can be found here:
+/// <https://graphviz.org/doc/info/command.html>.
 pub enum CommandArg {
     /// any custom argument.
     ///
@@ -142,7 +141,7 @@ impl CommandArg {
 /// Various algorithms for projecting abstract graphs into a space for
 /// visualization
 ///
-/// https://graphviz.org/docs/layouts/
+/// <https://graphviz.org/docs/layouts/>
 #[derive(Debug, Copy, Clone)]
 pub enum Layout {
     Dot,
@@ -158,7 +157,7 @@ pub enum Layout {
 /// Various graphic and data formats for end user, web, documents and other
 /// applications.
 ///
-/// https://graphviz.org/docs/outputs/
+/// <https://graphviz.org/docs/outputs/>
 #[derive(Debug, Copy, Clone)]
 pub enum Format {
     Bmp,

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -59,10 +59,10 @@ pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<String> {
         let path = f.path().to_string_lossy().to_string();
         do_exec(path, args).and_then(|o| {
             if o.status.code().map(|c| c != 0).unwrap_or(true) {
-                let mes = String::from_utf8_lossy(&*o.stderr).to_string();
+                let mes = String::from_utf8_lossy(&o.stderr).to_string();
                 Err(std::io::Error::new(ErrorKind::Other, mes))
             } else {
-                Ok(String::from_utf8_lossy(&*o.stdout).to_string())
+                Ok(String::from_utf8_lossy(&o.stdout).to_string())
             }
         })
     })
@@ -225,11 +225,11 @@ mod tests {
 
     use crate::printer::{DotPrinter, PrinterContext};
 
-    use super::{exec, CommandArg, CommandArg::*, Format};
+    use super::{exec, CommandArg, Format};
 
     #[test]
     fn error_test() {
-        let mut g = graph!(id!("id"));
+        let g = graph!(id!("id"));
         let mut ctx = PrinterContext::default();
         ctx.always_inline();
         let empty = exec(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,10 @@
 //!
 //! # Description:
 //! This library contains 4 primary functions:
-//!  - parse: parses a string in the dot [`notation`] into a [Graph].
-//!  - print: serializes a [Graph] into a string given a [DotPrinter].
-//!  - exec: executes the [`dot` command line executable] given a [Graph].
-//!  - exec_dot: executes the [`dot` command line executable] given a string in
+//!  - [parse]: parses a string in the dot [`notation`] into a [Graph].
+//!  - [print](crate::print): serializes a [Graph] into a string given a [DotPrinter].
+//!  - [exec]: executes the [`dot` command line executable] given a [Graph].
+//!  - [exec_dot]: executes the [`dot` command line executable] given a string in
 //!    the dot [`notation`].
 //!
 //! # Examples:
@@ -134,19 +134,19 @@ pub fn parse(dot: &str) -> Result<Graph, String> {
     parser::parse(dot)
 }
 
-/// Prints a given graph according to a given [`PrinterContext`]
+/// Serializes a [Graph] into a string given a [DotPrinter].
 pub fn print(graph: Graph, ctx: &mut PrinterContext) -> String {
     graph.print(ctx)
 }
 
 /// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
-/// using the given [Graph], [PrinterContext] and command line arguments
+/// using the given [Graph], [PrinterContext] and command line arguments.
 pub fn exec(graph: Graph, ctx: &mut PrinterContext, args: Vec<CommandArg>) -> io::Result<String> {
     cmd::exec(print(graph, ctx), args)
 }
 
 /// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
-/// using the given string dot notation, [PrinterContext] and command line arguments
+/// using the given string dot notation, [PrinterContext] and command line arguments.
 pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<String> {
     cmd::exec(dot_graph, args)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,12 @@
-//! The library allows to interact with [`graphviz`] format.
+//! The library provides functionality for interacting with the [`graphviz` DOT language].
 //!
 //! # Description:
-//! Essentially, it starts from 3 base methods:
-//!  - parse: a source of a dot file in the dot [`notation`]. The output format is a [Graph].
-//!  - print: [Graph] and [DotPrinter] provides an ability to transform a graph into string
-//!         following the [`notation`]
-//!  - exec: an ability to [`execute`] a cmd graphviz engine into different formats and etc.
-//!  - exec_dot: an ability to [`execute`] a cmd graphviz engine into different formats from a prepared string containing a dot graph.
+//! This library contains 4 primary functions:
+//!  - parse: parses a string in the dot [`notation`] into a [Graph].
+//!  - print: serializes a [Graph] into a string given a [DotPrinter].
+//!  - exec: executes the [`dot` command line executable] given a [Graph].
+//!  - exec_dot: executes the [`dot` command line executable] given a string in
+//!    the dot [`notation`].
 //!
 //! # Examples:
 //! ```rust
@@ -101,8 +101,9 @@
 //! ```
 //!
 //! [`graphviz`]: https://graphviz.org/
+//! [`graphviz` DOT language]: https://graphviz.org/doc/info/lang.html
 //! [`notation`]: https://graphviz.org/doc/info/lang.html
-//! [`execute`]: https://graphviz.org/doc/info/command.html
+//! [`dot` command line executable]: https://graphviz.org/doc/info/command.html
 #![allow(non_camel_case_types)]
 #![allow(dead_code)]
 pub extern crate dot_generator;
@@ -128,8 +129,7 @@ pub mod printer;
 extern crate pest_derive;
 extern crate pest;
 
-/// Parses a given string into a graph format that can be used afterwards or returning
-/// an string with an error description
+/// Parses a string into a [Graph].
 pub fn parse(dot: &str) -> Result<Graph, String> {
     parser::parse(dot)
 }
@@ -139,12 +139,14 @@ pub fn print(graph: Graph, ctx: &mut PrinterContext) -> String {
     graph.print(ctx)
 }
 
-/// Executes a given graph using a dot cmd client
+/// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
+/// using the given [Graph], [PrinterContext] and command line arguments
 pub fn exec(graph: Graph, ctx: &mut PrinterContext, args: Vec<CommandArg>) -> io::Result<String> {
     cmd::exec(print(graph, ctx), args)
 }
 
-/// Executes a given string representation of the graph using a dot cmd client
+/// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
+/// using the given string dot notation, [PrinterContext] and command line arguments
 pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<String> {
     cmd::exec(dot_graph, args)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,11 +153,7 @@ pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<String> 
 
 #[cfg(test)]
 mod tests {
-    use std::{
-        fs,
-        path::{Path, PathBuf},
-        process::Command,
-    };
+    use std::{fs, process::Command};
 
     use dot_generator::*;
     use dot_structures::*;
@@ -226,7 +222,7 @@ mod tests {
 
     #[test]
     fn exec_test() {
-        let mut g = graph!(id!("id");
+        let g = graph!(id!("id");
             node!("nod"),
             subgraph!("sb";
                 edge!(node_id!("a") => subgraph!(;
@@ -275,7 +271,7 @@ mod tests {
 
     #[test]
     fn output_exec_from_test() {
-        let mut g = graph!(id!("id");
+        let g = graph!(id!("id");
              node!("nod"),
              subgraph!("sb";
                  edge!(node_id!("a") => subgraph!(;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -219,19 +219,12 @@ fn process_graph(rule: Pair<Rule>) -> Graph {
 mod test {
     use dot_generator::{attr, edge, graph, id, node, node_id, port, stmt, subgraph};
     use dot_structures::*;
-    use pest::{
-        error::Error,
-        iterators::{Pair, Pairs},
-        RuleType,
-    };
+    use pest::iterators::Pair;
 
-    use crate::{
-        parser::{
-            do_parse, down, parse, process_attr, process_attr_list, process_attr_stmt,
-            process_edge, process_edge_stmt, process_id, process_node, process_node_id,
-            process_stmt, process_vertex, DotParser, Rule, Stmt, Vertex,
-        },
-        pest::Parser,
+    use crate::parser::{
+        do_parse, parse, process_attr, process_attr_list, process_attr_stmt, process_edge,
+        process_edge_stmt, process_id, process_node, process_node_id, process_stmt, process_vertex,
+        Rule, Stmt, Vertex,
     };
 
     fn _parse(input: &str, ty: Rule) -> Pair<Rule> {

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -1,5 +1,4 @@
-//! It allows to transform a graph into a string carrying dot info according
-//! to the notation.
+//! Serialize a [Graph] into a string according to the [`graphviz` DOT language].
 //!
 //! # Example:
 //! ```rust
@@ -12,11 +11,14 @@
 //!         assert_eq!(s.print(&mut ctx), "subgraph id {\n    abc\n    a -- b \n}".to_string());
 //!     }
 //! ```
+//!
+//! [`graphviz` DOT language]: https://graphviz.org/doc/info/lang.html
 use dot_structures::{
     Attribute, Edge, EdgeTy, Graph, GraphAttributes, Id, Node, NodeId, Port, Stmt, Subgraph, Vertex,
 };
 
 /// Context allows to customize the output of the file.
+///
 /// # Example:
 /// ```rust
 /// fn ctx() {
@@ -45,29 +47,31 @@ pub struct PrinterContext {
 }
 
 impl PrinterContext {
-    /// everything in one line
+    /// Print everything on one line.
     pub fn always_inline(&mut self) -> &mut PrinterContext {
         self.l_s_m = self.l_s_i.clone();
         self.l_s = self.l_s_i.clone();
         self
     }
-    /// add semi at the end of every line
+    /// Add a semicolon at the end of every line.
     pub fn with_semi(&mut self) -> &mut PrinterContext {
         self.semi = true;
         self
     }
-    /// set a step of the indent
+    /// Set a step of the indent.
     pub fn with_indent_step(&mut self, step: usize) -> &mut PrinterContext {
         self.indent_step = step;
         self
     }
-    /// set a specific line sep
+    /// Set a specific line separator.
     pub fn with_line_sep(&mut self, sep: String) -> &mut PrinterContext {
         self.l_s = sep.clone();
         self.l_s_m = sep;
         self
     }
-    /// set a line len enough to fit in a line
+    /// Set the max line length.
+    ///
+    /// The default value is 90.
     pub fn with_inline_size(&mut self, inline_s: usize) -> &mut PrinterContext {
         self.inline_size = inline_s;
         self
@@ -132,7 +136,8 @@ impl Default for PrinterContext {
     }
 }
 
-/// The trait allowing to transform a graph into the dot file:
+/// The trait for serailizing a [Graph] into the `graphviz` DOT language:
+///
 /// # Example:
 ///  ```rust
 ///     fn test(){


### PR DESCRIPTION
Rewrites some existing docs to be a bit clearer, and adds more docs to some structures.

I also resolved some warnings about unused imports and clippy lints. These changes can be found in 48356adfa24c7ad5c9ca3207dfaffe3944b1623b.