### PR TITLE
Change exec function to return Vec<u8> instead of String.

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -52,7 +52,7 @@ use std::{
 
 use tempfile::NamedTempFile;
 
-pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<String> {
+pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<Vec<u8>> {
     let args = args.into_iter().map(|a| a.prepare()).collect();
     temp_file(graph).and_then(|f| {
         let path = f.path().to_string_lossy().to_string();
@@ -61,7 +61,7 @@ pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<String> {
                 let mes = String::from_utf8_lossy(&o.stderr).to_string();
                 Err(std::io::Error::new(ErrorKind::Other, mes))
             } else {
-                Ok(String::from_utf8_lossy(&o.stdout).to_string())
+                Ok(o.stdout)
             }
         })
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,13 +141,13 @@ pub fn print(graph: Graph, ctx: &mut PrinterContext) -> String {
 
 /// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
 /// using the given [Graph], [PrinterContext] and command line arguments.
-pub fn exec(graph: Graph, ctx: &mut PrinterContext, args: Vec<CommandArg>) -> io::Result<String> {
+pub fn exec(graph: Graph, ctx: &mut PrinterContext, args: Vec<CommandArg>) -> io::Result<Vec<u8>> {
     cmd::exec(print(graph, ctx), args)
 }
 
 /// Executes the [`dot` command line executable](https://graphviz.org/doc/info/command.html)
 /// using the given string dot notation, [PrinterContext] and command line arguments.
-pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<String> {
+pub fn exec_dot(dot_graph: String, args: Vec<CommandArg>) -> io::Result<Vec<u8>> {
     cmd::exec(dot_graph, args)
 }
 
@@ -265,8 +265,8 @@ mod tests {
         let file = fs::read_to_string(p).unwrap();
 
         fs::remove_file(p).unwrap();
-        assert_eq!("", out);
-        assert_eq!(out_svg, file);
+        assert_eq!(Vec::<u8>::new(), out);
+        assert_eq!(out_svg, file.as_bytes());
     }
 
     #[test]


### PR DESCRIPTION
This allows the exec function to work when dot returns binary data not compatible with utf-8. Png is a example of one such output.