### PR TITLE
Remove unnecessary space added when edge attributes is empty.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,7 +232,7 @@ mod tests {
             ),
             edge!(node_id!("a1") => node_id!(esc "a2"))
         );
-        let graph_str = "graph id {\n    nod\n    subgraph sb {\n        a -- subgraph  {n[color=black,shape=egg]} \n    }\n    a1 -- \"a2\" \n}";
+        let graph_str = "graph id {\n    nod\n    subgraph sb {\n        a -- subgraph  {n[color=black,shape=egg]}\n    }\n    a1 -- \"a2\"\n}";
 
         let mut ctx = PrinterContext::default();
         assert_eq!(graph_str, g.print(&mut ctx));

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -420,7 +420,7 @@ mod tests {
         println!("{}", s.print(&mut ctx));
         assert_eq!(
             s.print(&mut ctx),
-            "subgraph id {\n    abc\n    a -- b \n}".to_string()
+            "subgraph id {\n    abc\n    a -- b\n}".to_string()
         );
     }
 
@@ -440,7 +440,7 @@ mod tests {
           edge!(node_id!("aa") => node_id!("aaa") => node_id!("v"))
         );
         assert_eq!(
-            r#"strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2 }aaa[color=red]aaa -> bbb }aa -> be -> subgraph v {d -> aaa }aa -> aaa -> v}"#,
+            r#"strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2}aaa[color=red]aaa -> bbb}aa -> be -> subgraph v {d -> aaa}aa -> aaa -> v}"#,
             g.print(&mut ctx)
         );
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -327,13 +327,17 @@ fn print_edge(edge: &Edge, ctx: &mut PrinterContext) -> String {
             ty: EdgeTy::Pair(l, r),
             attributes,
         } => {
-            format!(
-                "{} {} {} {}",
-                l.print(ctx),
-                bond,
-                r.print(ctx),
-                attributes.print(ctx)
-            )
+            if attributes.is_empty() {
+                format!("{} {} {}", l.print(ctx), bond, r.print(ctx))
+            } else {
+                format!(
+                    "{} {} {} {}",
+                    l.print(ctx),
+                    bond,
+                    r.print(ctx),
+                    attributes.print(ctx)
+                )
+            }
         }
         Edge {
             ty: EdgeTy::Chain(vs),


### PR DESCRIPTION
Resolves #29 

This resolves an issue which causes printed output to contain an unneeded space if edge attributes are empty. I've adjusted the relevant test output to account for the change.

The difference is subtle, but it's both visible below and in the changes. 

Before change  `vv {a2 -> b2 }`, `aaa -> bbb }`:

```
strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2 }aaa[color=red]aaa -> bbb }aa -> be -> subgraph v {d -> aaa }aa -> aaa -> v}
```

After change  `vv {a2 -> b2}`, `aaa -> bbb}`:
```
strict digraph t {aa[color=green]subgraph v {aa[shape=square]subgraph vv {a2 -> b2}aaa[color=red]aaa -> bbb}aa -> be -> subgraph v {d -> aaa}aa -> aaa -> v}