### PR TITLE
Cleanup statement indentation and add tests validating semi-colon and indent fixes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@ mod tests {
             }
         }
 
-        assert_eq!(178896, g.print(&mut PrinterContext::default()).len())
+        assert_eq!(148898, g.print(&mut PrinterContext::default()).len())
     }
 
     #[cfg(windows)]
@@ -232,7 +232,7 @@ mod tests {
             ),
             edge!(node_id!("a1") => node_id!(esc "a2"))
         );
-        let graph_str = "graph id {\n    nod\n    subgraph sb {\n        a -- subgraph  {n[color=black,shape=egg]}\n    }\n    a1 -- \"a2\"\n}";
+        let graph_str = "graph id {\n  nod\n  subgraph sb {\n    a -- subgraph  {n[color=black,shape=egg]}\n  }\n  a1 -- \"a2\"\n}";
 
         let mut ctx = PrinterContext::default();
         assert_eq!(graph_str, g.print(&mut ctx));


### PR DESCRIPTION
This resolves #30 

Semi-colon test output:
![image](https://github.com/besok/graphviz-rust/assets/106980485/2f588ceb-cb7d-4dab-99cd-7bce1e04e4a9)

Indent-test output:
![image](https://github.com/besok/graphviz-rust/assets/106980485/6825f96e-20f6-4a80-9313-eef01d66fc7d)
