### PR TITLE
Fix Windows temporary files Error for exec (Fixes `Error: dot: can't open C:..`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,5 @@ into-attr-derive = "0.2.1"
 pest = "2.0"
 pest_derive = "2.0"
 rand = "0.8.4"
-tempfile = "3.2.0"
+tempfile = "3.13.0"
 [dev-dependencies]

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -59,10 +59,10 @@ pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<Vec<u8>> 
         do_exec(path.to_string_lossy().to_string(), args).and_then(|o| {
             if o.status.code().map(|c| c != 0).unwrap_or(true) {
                 let mes = String::from_utf8_lossy(&o.stderr).to_string();
-                path.close().unwrap();
+                path.close()?;
                 Err(std::io::Error::new(ErrorKind::Other, mes))
             } else {
-                path.close().unwrap();
+                path.close()?;
                 Ok(o.stdout)
             }
         })

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -46,7 +46,8 @@
 //!
 //! [`dot` command line executable]: https://graphviz.org/doc/info/command.html
 use std::{
-    io::{self, ErrorKind, Write}, process::{Command, Output}
+    io::{self, ErrorKind, Write},
+    process::{Command, Output},
 };
 
 use tempfile::NamedTempFile;
@@ -55,7 +56,7 @@ pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<Vec<u8>> 
     let args = args.into_iter().map(|a| a.prepare()).collect();
     temp_file(graph).and_then(|f| {
         let path = f.into_temp_path();
-        do_exec(path.to_string_lossy().to_string(), args).and_then( |o| {
+        do_exec(path.to_string_lossy().to_string(), args).and_then(|o| {
             if o.status.code().map(|c| c != 0).unwrap_or(true) {
                 let mes = String::from_utf8_lossy(&o.stderr).to_string();
                 path.close().unwrap();

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -46,8 +46,7 @@
 //!
 //! [`dot` command line executable]: https://graphviz.org/doc/info/command.html
 use std::{
-    io::{self, ErrorKind, Write},
-    process::{Command, Output},
+    io::{self, ErrorKind, Write}, process::{Command, Output}
 };
 
 use tempfile::NamedTempFile;
@@ -55,12 +54,14 @@ use tempfile::NamedTempFile;
 pub(crate) fn exec(graph: String, args: Vec<CommandArg>) -> io::Result<Vec<u8>> {
     let args = args.into_iter().map(|a| a.prepare()).collect();
     temp_file(graph).and_then(|f| {
-        let path = f.path().to_string_lossy().to_string();
-        do_exec(path, args).and_then(|o| {
+        let path = f.into_temp_path();
+        do_exec(path.to_string_lossy().to_string(), args).and_then( |o| {
             if o.status.code().map(|c| c != 0).unwrap_or(true) {
                 let mes = String::from_utf8_lossy(&o.stderr).to_string();
+                path.close().unwrap();
                 Err(std::io::Error::new(ErrorKind::Other, mes))
             } else {
+                path.close().unwrap();
                 Ok(o.stdout)
             }
         })


### PR DESCRIPTION
I noticed that on Windows, the execution feature seems to be broken. I tested this on a few machines and got errors like `Error: dot: can't open <path of temporary file> Permission denied`.

On Linux, however, everything seemed to work fine.


To mitigate this, I used the `into_temp_path` from `tempfile`. This also makes sense, as we only want a path version of the temporary file at this point to pass to `dot`. The issues previously (afaik) was that the file was still open from writing the dot graph content and thus could not be opened by `dot` itself (resulting in a Permission Denied error on Windows).
The temp path is then closed after `do_exec` finishes, dropping and deleting the temp file.