### PR TITLE
use space instead of comma as separator of gattrs to make the output valid DOT syntax

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -290,7 +290,7 @@ impl DotPrinter for Vec<Attribute> {
             ctx.indent_shrink();
             r
         } else {
-            format!("[{}]", attrs.join(","))
+            format!("[{}]", attrs.join(" "))
         }
     }
 }


### PR DESCRIPTION
the current code emits invalid DOT syntax when using multiple gattrs at once, for example:
```rust
        graph.add_stmt(Stmt::GAttribute(
            graphviz_rust::dot_structures::GraphAttributes::Graph(vec![
                GraphAttributes::bgcolor(color_name::black),
                GraphAttributes::rankdir(rankdir::TB),
            ]),
        ));
```

it emits the following dot with wrong syntax:
```dot
graph[bgcolor=black,rankdir=TB]
```

instead it should be:
```dot
graph[bgcolor=black rankdir=TB]
```

fix this by using space as a separator instead of using a comma.