### PR TITLE
fix warning about hidden lifetime in do_parse

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -26,7 +26,7 @@ fn down(rule: Pair<Rule>) -> Pair<Rule> {
     rule.into_inner().next().unwrap()
 }
 
-fn do_parse(input: &str, ty: Rule) -> Result<Pairs<Rule>, Error<Rule>> {
+fn do_parse(input: &str, ty: Rule) -> Result<Pairs<'_, Rule>, Error<Rule>> {
     DotParser::parse(ty, input)
 }
 


### PR DESCRIPTION
the current code emits a warning when compiled using a recent rust compiler:
```
warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/parser.rs:29:20
   |
29 | fn do_parse(input: &str, ty: Rule) -> Result<Pairs<Rule>, Error<Rule>> {
   |                    ^^^^                      ^^^^^^^^^^^ the same lifetime is hidden here
   |                    |
   |                    the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
   = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
   |
29 | fn do_parse(input: &str, ty: Rule) -> Result<Pairs<'_, Rule>, Error<Rule>> {
   |                                                    +++
```


fix the warning by adding the missing lifetime parameter.