### PR TITLE
Add Eq on command attributes

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -144,7 +144,7 @@ impl CommandArg {
 /// visualization
 ///
 /// <https://graphviz.org/docs/layouts/>
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Layout {
     Dot,
     Neato,
@@ -160,7 +160,7 @@ pub enum Layout {
 /// applications.
 ///
 /// <https://graphviz.org/docs/outputs/>
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Format {
     Bmp,
     Cgimage,


### PR DESCRIPTION
Hello, I'm making this small PR because I found myself doing the following in a markup language project where I need to parse graphviz commands:
```rust
fn layout_to_str(layout: Layout) -> &'static str
{
	match layout {
		Layout::Dot => "Dot",
		Layout::Neato => "Neato",
		Layout::Twopi => "Twopi",
		Layout::Circo => "Circo",
		Layout::Fdp => "Fdp",
		Layout::Asage => "Asage",
		Layout::Patchwork => "Patchwork",
		Layout::Sfdp => "Sfdp",
	}
}
...
assert_eq!(layout_to_str(parsed.layout) == layout_to_str(Layout::Dot));
assert_eq!(parsed.layout == Layout::Dot); // doesn't compile
```
I have to do this when comparing against an enum variant for the sake of testing.

According to rust-lang guidelines, it's good practice that public crate types implement common std traits: https://rust-lang.github.io/api-guidelines/interoperability.html

I did not add `Hash` or `Display`, however their addition might be justified.